### PR TITLE
JWT: change behaviour to match spec signature

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -4,9 +4,14 @@ class TokenError extends Error {}
 
 class B64URL {
 	static encode(data) {
-		let b64 = Buffer.from(data).toString('base64');
+		const b64 = Buffer.from(data).toString('base64');
+		return this.toURLB64(b64);
+	}
+
+	static toURLB64(b64str) {
+		let b64 = b64str;
 		const replacements = [
-			[/=/g, ''],
+			[/=$/g, ''],
 			[/\+/g, '-'],
 			[/\//g, '_'],
 		];
@@ -43,25 +48,29 @@ class B64URL {
 }
 
 class Token {
+	static stringify_utf8(json) {
+		return Buffer.from(JSON.stringify(json)).toString('utf8');
+	}
+
 	static create(payload, sk) {
-		const b64_payload = B64URL.encode(JSON.stringify(payload));
+		const b64_payload = B64URL.encode(this.stringify_utf8(payload));
 
 		let header = {
 			alg: 'HS256',
 			typ: 'JWT'
 		};
-		header = B64URL.encode(JSON.stringify(header));
+		header = B64URL.encode(this.stringify_utf8(header));
 
-		let signature = this.sign({ header, payload: b64_payload }, sk);
-		signature = B64URL.encode(signature);
+		let token_no_sign = `${header}.${b64_payload}`;
+		let signature = this.sign(token_no_sign, sk);
+		signature = B64URL.toURLB64(signature);
 
-		return `${header}.${b64_payload}.${signature}`;
+		return `${token_no_sign}.${signature}`;
 	}
 
-	static sign({ header, payload }, secret_key) {
+	static sign(str, secret_key) {
 		const hmac = Crypto.createHmac('sha256', secret_key);
-		const input = `${header}.${payload}`;
-		hmac.update(input);
+		hmac.update(str);
 		return hmac.digest('base64');
 	}
 
@@ -71,9 +80,8 @@ class Token {
 			throw new TokenError('Invalid number of fragments');
 		}
 
-		const [ header, payload, signed ] = fragments;
+		const [ header, payload, signature ] = fragments;
 
-		const received_signature = B64URL.decode(signed);
 		const body = JSON.parse(B64URL.decode(payload));
 
 		if(body.nbf && body.nbf > (Date.now() / 1000)) {
@@ -84,8 +92,8 @@ class Token {
 			throw new TokenError('Token: expired token');
 		}
 
-		const signature = this.sign({ header, payload }, sk);
-		if(signature !== received_signature) {
+		const computed_signature = B64URL.toURLB64(this.sign(`${header}.${payload}`, sk));
+		if(computed_signature !== signature) {
 			throw new TokenError('Token: invalid signature');
 		}
 

--- a/test/token.js
+++ b/test/token.js
@@ -17,7 +17,7 @@ const token_generator = new TokenGenerator({
 });
 
 const now = new Date(1628514905137);
-const example_token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2Mjg1MTQ5MDUsImV4cCI6MTYyODUxODUwNSwiaXNzIjoiaXNzdWVyLW9uZSIsImRhdGEiOiJwbGVwIn0.RTkwekY3M3hPOGpmQlFQeVhCL1dhOE5PYlFna2hvVS9TL3dhZ3FXekZWVT0';
+const example_token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2Mjg1MTQ5MDUsImV4cCI6MTYyODUxODUwNSwiaXNzIjoiaXNzdWVyLW9uZSIsImRhdGEiOiJwbGVwIn0.E90zF73xO8jfBQPyXB_Wa8NObQgkhoU_S_wagqWzFVU';
 
 describe('Tokens', () => {
 	afterEach(() => {


### PR DESCRIPTION
jwt.io validates signature as non-b64 encoded